### PR TITLE
Add timeout to workflow

### DIFF
--- a/.github/workflows/base-tests.yml
+++ b/.github/workflows/base-tests.yml
@@ -1,6 +1,10 @@
 name: Base tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      -main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
The last run of https://github.com/AnHeuermann/NonLinearSystemNeuralNetworkFMU.jl/actions/runs/2714185642 took 6 hours because OMC got stuck.

Adding a timeout on job-level to prevent this in the future.