### PR TITLE
Better error messages

### DIFF
--- a/src/genFMUs.jl
+++ b/src/genFMUs.jl
@@ -164,7 +164,7 @@ function generateFMU(modelName::String,
   end
 
   if !isfile(joinpath(workingDir, modelName*".fmu"))
-    error("Could not generate FMU! Check log file:\n$(abspath(logFilePath))")
+    throw(OpenModelicaError("Could not generate FMU!", abspath(logFilePath)))
   end
 
   return joinpath(workingDir, modelName*".fmu")

--- a/src/profiling.jl
+++ b/src/profiling.jl
@@ -97,7 +97,9 @@ function simulateWithProfiling(modelName::String,
   profJsonFile = abspath(joinpath(workingDir, modelName*"_prof.json"))
   infoJsonFile = abspath(joinpath(workingDir, modelName*"_info.json"))
   resultFile = abspath(joinpath(workingDir, modelName*"_res."*outputFormat))
-  @assert isfile(profJsonFile) && isfile(infoJsonFile) && isfile(resultFile) "Simulation failed, no files generated."
+  if !(isfile(profJsonFile) && isfile(infoJsonFile) && isfile(resultFile))
+    throw(OpenModelicaError("Simulation failed, no files generated.", abspath(logFilePath)))
+  end
   return (profJsonFile, infoJsonFile, resultFile)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -89,6 +89,9 @@ function Base.showerror(io::IO, e::ProgramNotFoundError)
   end
 end
 
+"""
+Minimum version not sattisfied error.
+"""
 struct MinimumVersionError <: Exception
   program::String
   minimumVersion::String
@@ -100,10 +103,27 @@ function Base.showerror(io::IO, e::MinimumVersionError)
   print(io, "Using version $(e.currentVersion).")
 end
 
-
+"""
+String not found in searched string error.
+"""
 struct StringNotFoundError <: Exception
   searchString::String
 end
 function Base.showerror(io::IO, e::StringNotFoundError)
   print(io, "Could not find string \"", e.searchString, " \"")
+end
+
+"""
+OpenModelica error with log file.
+"""
+struct OpenModelicaError <: Exception
+  msg::String
+  logFile::String
+end
+function Base.showerror(io::IO, e::OpenModelicaError)
+  println(io, e.msg)
+  println(io, "Log file: ", e.logFile)
+  if isfile(e.logFile)
+    print(io, read(e.logFile, String))
+  end
 end


### PR DESCRIPTION
  - Throw `OpenModelicaError` error and dump log file if OpenModelica failed to simulate or translate model or FMU.