### PR TITLE
Restructured min-max boundary values

### DIFF
--- a/docs/src/main.md
+++ b/docs/src/main.md
@@ -3,10 +3,9 @@
 To perform all needed steps for data generation the following functions have to be executed:
 
   1. [`profiling`](@ref)
-  2. [`minMaxValuesReSim`](@ref)
-  3. [`generateFMU`](@ref)
-  4. [`addEqInterface2FMU`](@ref)
-  5. [`generateTrainingData`](@ref)
+  2. [`generateFMU`](@ref)
+  3. [`addEqInterface2FMU`](@ref)
+  4. [`generateTrainingData`](@ref)
 
 These functionalities are bundled in [`main`](@ref).
 

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -56,8 +56,13 @@ profilingInfo[1].iterationVariables
 
 So we can see, that equations `14` is the slowest non-linear equation system. It is called 2512 times and needs around 15% of the total simulation time, in this case that is around 592 $\mu s$.
 
-If we want to get the minimal and maximal values for the used variables `s` and `r` can get we can use [`minMaxValuesReSim`](@ref). This will re-simulate the Modelica model and read the simulation results to find the smallest and largest values for each given variable.
+During [`profiling`](@ref) function [`minMaxValuesReSim`](@ref) is called to re-simulate
+the Modelica model and read the simulation results to find the smallest and largest
+values for each given variable.
+
+We can check them by looking into
 
 ```@repl profilingexample
-(min, max)  = minMaxValuesReSim(profilingInfo[1].usingVars, modelName, moFiles, omc)
+profilingInfo[1].boundary.min
+profilingInfo[1].boundary.min
 ```

--- a/src/genTrainData.jl
+++ b/src/genTrainData.jl
@@ -24,10 +24,10 @@ include("fmiExtensions.jl")
                          fname::String,
                          eqId::Int64,
                          inputVars::Array{String},
-                         min::AbstractVector{<:Number}
-                         max::AbstractVector{<:Number},
+                         min::AbstractVector{T}
+                         max::AbstractVector{T},
                          outputVars::Array{String};
-                         N::Integer=1000)
+                         N::Integer=1000) where T <: Number
 
 Generate training data for given equation of FMU.
 
@@ -39,8 +39,8 @@ All input-output pairs are saved in `fname`.
   - `fname::String`:                  File name to save training data to.
   - `eqId::Int64`:                    Index of equation to generate training data for.
   - `inputVars::Array{String}`:       Array with names of input variables.
-  - `min::AbstractVector{<:Number}`:  Array with minimum value for each input variable.
-  - `max::AbstractVector{<:Number}`:  Array with maximum value for each input variable.
+  - `min::AbstractVector{T}`:         Array with minimum value for each input variable.
+  - `max::AbstractVector{T}`:         Array with maximum value for each input variable.
   - `outputVars::Array{String}`:      Array with names of output variables.
 
 # Keywords
@@ -48,7 +48,14 @@ All input-output pairs are saved in `fname`.
 
 See also [`generateFMU`](@ref), [`generateFMU`](@ref).
 """
-function generateTrainingData(fmuPath::String, fname::String, eqId::Int64, inputVars::Array{String}, min::AbstractVector{<:Number}, max::AbstractVector{<:Number}, outputVars::Array{String}; N::Integer=1000)
+function generateTrainingData(fmuPath::String,
+                              fname::String,
+                              eqId::Int64,
+                              inputVars::Array{String},
+                              min::AbstractVector{T},
+                              max::AbstractVector{T},
+                              outputVars::Array{String};
+                              N::Integer=1000) where T <: Number
   #ENV["JULIA_DEBUG"] = "FMICore"
   nInputs = length(inputVars)
   nOutputs = length(outputVars)

--- a/test/includeOnnxTest.jl
+++ b/test/includeOnnxTest.jl
@@ -32,7 +32,13 @@ function runIncludeOnnxTests()
     interfaceFmu = joinpath(fmuDir, "$(modelname).interface.fmu")
     onnxFmu = joinpath(fmuDir, "$(modelname).onnx.fmu")
     rm(onnxFmu, force=true)
-    profilingInfo = ProfilingInfo[ProfilingInfo(EqInfo(14, 2512, 2.111228e6, 54532.0, 0.12241628639186376), ["y"], [11], ["s", "r"])]
+    profilingInfo = ProfilingInfo[
+      ProfilingInfo(
+        EqInfo(14, 2512, 2.111228e6, 54532.0, 0.12241628639186376),
+        ["y"],
+        [11],
+        ["s", "r"],
+        NonLinearSystemNeuralNetworkFMU.MinMaxBoundaryValues([0.0, 0.95], [1.4087228258248679, 3.15]))]
     onnxFiles = [abspath(@__DIR__, "nn", "simpleLoop_eq14.onnx")]
 
     pathToFmu = NonLinearSystemNeuralNetworkFMU.buildWithOnnx(interfaceFmu, modelname, profilingInfo, onnxFiles; tempDir=tempDir)

--- a/test/mainTest.jl
+++ b/test/mainTest.jl
@@ -27,7 +27,6 @@ function runMainTest()
 
   @testset "Generate Data (main)" begin
     (csvFiles, fmu, profilingInfo) = NonLinearSystemNeuralNetworkFMU.main(modelName, moFiles; workdir=workingDir, reuseArtifacts=false, N=10)
-    @test isfile(joinpath(workingDir, "minMax.bson"))
     @test isfile(joinpath(workingDir, "profilingInfo.bson"))
     @test isfile(joinpath(workingDir, "simpleLoop.fmu"))
     @test isfile(joinpath(workingDir, "simpleLoop.interface.fmu"))
@@ -39,6 +38,8 @@ function runMainTest()
     @test profilingInfo[1].eqInfo.id == 14
     @test profilingInfo[1].iterationVariables == ["y"]
     @test sort(profilingInfo[1].usingVars) == ["r","s"]
+    @test profilingInfo[1].boundary.min[1] ≈ 0.0 && profilingInfo[1].boundary.max[1] ≈ 1.4087228258248679
+    @test profilingInfo[1].boundary.min[2] ≈ 0.95 && profilingInfo[1].boundary.max[2] ≈ 3.15
     rm(joinpath(workingDir), recursive=true, force=true)
   end
 end

--- a/test/profilingTests.jl
+++ b/test/profilingTests.jl
@@ -32,20 +32,12 @@ function runProfilingTests()
     @test profilingInfo[1].eqInfo.id == 14
     @test profilingInfo[1].iterationVariables == ["y"]
     @test sort(profilingInfo[1].usingVars) == ["r","s"]
+    @test profilingInfo[1].boundary.min[1] ≈ 0.0 && profilingInfo[1].boundary.max[1] ≈ 1.4087228258248679
+    @test profilingInfo[1].boundary.min[2] ≈ 0.95 && profilingInfo[1].boundary.max[2] ≈ 3.15
     # NLS from initialization system
     @test profilingInfo[2].eqInfo.id == 6
     @test profilingInfo[2].iterationVariables == ["y"]
     @test sort(profilingInfo[2].usingVars) == ["r","s"]
-    rm(joinpath(workingDir,modelName), recursive=true)
-  end
-
-  @testset "Min-max for usingVars" begin
-    profilingInfo = NonLinearSystemNeuralNetworkFMU.profiling(modelName, moFiles; workingDir=workingDir, threshold=0)
-    (min, max)  = NonLinearSystemNeuralNetworkFMU.minMaxValuesReSim(profilingInfo[1].usingVars, modelName, moFiles, workingDir=workingDir)
-    # s = sqrt((2-time)*0.9), time = 0..2
-    # r = 1..3
-    @test min[1] ≈ 0.0 && max[1] ≈ 1.4087228258248679
-    @test min[2] ≈ 0.95 && max[2] ≈ 3.15
     rm(joinpath(workingDir,modelName), recursive=true)
   end
 end


### PR DESCRIPTION
The minimum and maximum values saved in minMax.bson where missing information where the values correspond to, see https://github.com/AnHeuermann/NonLinearSystemNeuralNetworkFMU.jl/issues/57#issuecomment-1346196826.

Moved boundary values into `ProfilingInfo` next to the corresponding `usingVars`.

## Changes

  - Now part of struct ProfilingInfo
  - New type MinMaxBoundaryValues with two constructors
  - minMaxValuesReSim() now get's called from within profiling()
  - Updated tests
  - Updated documentation