### PR TITLE
Simplify getter

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -232,6 +232,11 @@ end
  #   Getter and setter functions
 =#
 
+"""
+    getProfilingInfo(bsonFile)
+
+Read `ProfilingInfo` array from binary JSON file.
+"""
 function getProfilingInfo(bsonFile::String)::Array{ProfilingInfo}
   # load BSON file
   dict = BSON.load(bsonFile, @__MODULE__)
@@ -245,9 +250,9 @@ end
   - `bsonFile::String`:  name of the binary JSON file
   - `eqNumber::Int`:  number of the slowest equation
 # Return:
-  - array of the using variables and length of the array
+  - Array of used variables
 """
-function getUsingVars(bsonFile::String, eqNumber::Int)
+function getUsingVars(bsonFile::String, eqNumber::Int)::Array{String}
   profilingInfo = getProfilingInfo(bsonFile)
   # Find array element with eqNumber
   for prof in profilingInfo
@@ -255,6 +260,8 @@ function getUsingVars(bsonFile::String, eqNumber::Int)
       return prof.usingVars
     end
   end
+
+  error("No usingVars array found for equation $(eqNumber)")
 end
 
 """
@@ -264,9 +271,9 @@ end
   - `bsonFile::String`:  name of the binary JSON file
   - `eqNumber::Int`:  number of the slowest equation
 # Return:
-  - array of the iteration variables and length of the array
+  - Array of iteration variables
 """
-function getIterationVars(bsonFile::String, eqNumber::Int)
+function getIterationVars(bsonFile::String, eqNumber::Int)::Array{String}
   profilingInfo = getProfilingInfo(bsonFile)
   # Find array element with eqNumber
   for prof in profilingInfo
@@ -274,6 +281,8 @@ function getIterationVars(bsonFile::String, eqNumber::Int)
       return prof.iterationVariables
     end
   end
+
+  error("No iterationVariables array found for equation $(eqNumber)")
 end
 
 """
@@ -283,9 +292,9 @@ end
   - `bsonFile::String`:  name of the binary JSON file
   - `eqNumber::Int`:  number of the slowest equation
 # Return:
-  - array of the inner equations and length of the array
+  - Array of inner equation indices
 """
-function getInnerEquations(bsonFile::String, eqNumber::Int)
+function getInnerEquations(bsonFile::String, eqNumber::Int)::Array{Int64}
   profilingInfo = getProfilingInfo(bsonFile)
   # Find array element with eqNumber
   for prof in profilingInfo
@@ -293,6 +302,8 @@ function getInnerEquations(bsonFile::String, eqNumber::Int)
       return prof.innerEquations
     end
   end
+
+  error("No innerEquations array found for equation $(eqNumber)")
 end
 
 """
@@ -319,6 +330,8 @@ function getMinMax(bsonFile::String, eqNumber::Int, inputArray::Vector{String})
       return [[min,max] for (min,max) in zip(prof.boundary.min[indices],prof.boundary.max[indices])]
     end
   end
+
+  error("No boundary array found for equation $(eqNumber)")
 end
 
 """
@@ -338,4 +351,6 @@ function getMinMax(bsonFile::String, eqNumber::Int, inputArray::Vector{Int})
       return [[min,max] for (min,max) in zip(prof.boundary.min[inputArray],prof.boundary.max[inputArray])]
     end
   end
+
+  error("No boundary array found for equation $(eqNumber)")
 end

--- a/test/mainTest.jl
+++ b/test/mainTest.jl
@@ -45,21 +45,21 @@ function runMainTest()
   end
 
   @testset "Test function getUsingVars" begin
-    usingVars, lenUsingVars  = NonLinearSystemNeuralNetworkFMU.getUsingVars(joinpath(workingDir, "profilingInfo.bson"), 14)
+    usingVars = NonLinearSystemNeuralNetworkFMU.getUsingVars(joinpath(workingDir, "profilingInfo.bson"), 14)
     @test sort(usingVars) == ["r","s"]
-    @test lenUsingVars == 2
+    @test length(usingVars) == 2
   end
 
   @testset "Test function getIterationVars" begin
-    iterationVars, lenIterationVars  = NonLinearSystemNeuralNetworkFMU.getIterationVars(joinpath(workingDir, "profilingInfo.bson"), 14)
+    iterationVars = NonLinearSystemNeuralNetworkFMU.getIterationVars(joinpath(workingDir, "profilingInfo.bson"), 14)
     @test iterationVars == ["y"]
-    @test lenIterationVars == 1
+    @test length(iterationVars) == 1
   end
 
   @testset "Test function getInnerEquations" begin
-    innerEq, lenInnerEq  = NonLinearSystemNeuralNetworkFMU.getInnerEquations(joinpath(workingDir, "profilingInfo.bson"), 14)
+    innerEq = NonLinearSystemNeuralNetworkFMU.getInnerEquations(joinpath(workingDir, "profilingInfo.bson"), 14)
     @test sort(innerEq) == [11]
-    @test lenInnerEq == 1
+    @test length(innerEq) == 1
   end
 
   @testset "Test function getMinMax" begin


### PR DESCRIPTION
@Chrissula I changed the return type of the getter functions. I removed the length of the array. You can just call `length()` on the array to get that information. Will this break your scripts?